### PR TITLE
Fix bindPreviewUseCase() in CameraXLivePreviewActivity.kt to match Java implementation

### DIFF
--- a/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/kotlin/CameraXLivePreviewActivity.kt
+++ b/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/kotlin/CameraXLivePreviewActivity.kt
@@ -264,19 +264,19 @@ class CameraXLivePreviewActivity :
     }
 
     private fun bindPreviewUseCase() {
+        if (!PreferenceUtils.isCameraLiveViewportEnabled(this)) {
+            return
+        }
         if (cameraProvider == null) {
             return
         }
         if (previewUseCase != null) {
             cameraProvider!!.unbind(previewUseCase)
         }
+
         previewUseCase = Preview.Builder().build()
-        val camera =
-                cameraProvider!!.bindToLifecycle(
-                        /* lifecycleOwner= */this,
-                        cameraSelector!!, previewUseCase
-                )
         previewUseCase!!.setSurfaceProvider(previewView!!.createSurfaceProvider())
+        cameraProvider!!.bindToLifecycle(/* lifecycleOwner= */this, cameraSelector!!, previewUseCase)
     }
 
     @SuppressLint("NewApi")


### PR DESCRIPTION
I was running into issues using the Kotlin sample on emulator. Looking into the issue, I noticed that this particular method was implemented differently from the Java version.

Resolves #20 