### PR TITLE
Trying to stop null cameraSource

### DIFF
--- a/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/CameraSourcePreview.java
+++ b/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/CameraSourcePreview.java
@@ -51,9 +51,7 @@ public class CameraSourcePreview extends ViewGroup {
   }
 
   private void start(CameraSource cameraSource) throws IOException {
-    if (cameraSource == null) {
-      stop();
-    }
+    stop();
 
     this.cameraSource = cameraSource;
 


### PR DESCRIPTION
Trying to stop a `null` camera source. Also, the validation for `null` source is already done on the `stop` method, so the check is redundant.