### PR TITLE
Add missing 'rightElbow' landmark

### DIFF
--- a/ios/quickstarts/vision/VisionExample/UIUtilities.swift
+++ b/ios/quickstarts/vision/VisionExample/UIUtilities.swift
@@ -150,6 +150,7 @@ public class UIUtilities {
         PoseLandmarkType.rightHip: [PoseLandmarkType.rightKnee],
         PoseLandmarkType.rightKnee: [PoseLandmarkType.rightAnkle],
         PoseLandmarkType.leftKnee: [PoseLandmarkType.leftAnkle],
+        PoseLandmarkType.rightElbow: [PoseLandmarkType.rightShoulder],
         PoseLandmarkType.leftElbow: [PoseLandmarkType.leftShoulder],
         PoseLandmarkType.leftWrist: [
           PoseLandmarkType.leftElbow, PoseLandmarkType.leftThumb,


### PR DESCRIPTION
The example detect but doesn't print the right elbow landmark. This PR add's the missing landmark.