### PR TITLE
Android/translate sample. Add internet permission to fix error when download model

### DIFF
--- a/android/translate/app/src/main/AndroidManifest.xml
+++ b/android/translate/app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.mlkit.samples.translate">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Add internet permission to fix error "com.google.mlkit.common.MlKitException: No existing model file" when downloading model.
[Link](https://github.com/googlesamples/mlkit/issues/157) to issue.