### PR TITLE
use kotlin's base type in PoseDetectorProcessor.kt

### DIFF
--- a/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/kotlin/posedetector/PoseDetectorProcessor.kt
+++ b/android/vision-quickstart/app/src/main/java/com/google/mlkit/vision/demo/kotlin/posedetector/PoseDetectorProcessor.kt
@@ -21,7 +21,7 @@ import android.util.Log
 import com.google.android.gms.tasks.Task
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.demo.GraphicOverlay
-import com.google.mlkit.vision.demo.java.VisionProcessorBase
+import com.google.mlkit.vision.demo.kotlin.VisionProcessorBase
 import com.google.mlkit.vision.pose.Pose
 import com.google.mlkit.vision.pose.PoseDetection
 import com.google.mlkit.vision.pose.PoseDetector
@@ -36,13 +36,13 @@ class PoseDetectorProcessor(
   private val rescaleZForVisualization: Boolean
 ) :
   VisionProcessorBase<Pose>(context) {
-  private val detector: PoseDetector
+  private val detector: PoseDetector = PoseDetection.getClient(options)
   override fun stop() {
     super.stop()
     detector.close()
   }
 
-  override fun detectInImage(image: InputImage): Task<Pose?>? {
+  override fun detectInImage(image: InputImage): Task<Pose> {
     return detector.process(image)
   }
 
@@ -67,7 +67,4 @@ class PoseDetectorProcessor(
     private const val TAG = "PoseDetectorProcessor"
   }
 
-  init {
-    detector = PoseDetection.getClient(options)
-  }
 }


### PR DESCRIPTION
PoseDetectorProcessor.kt  was extending the java's base class. Most likely it's a typo