### PR TITLE
Update SDK versions to build material-showcase in modern dev environments

### DIFF
--- a/android/material-showcase/app/build.gradle
+++ b/android/material-showcase/app/build.gradle
@@ -1,13 +1,14 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 31
+    namespace 'com.google.mlkit.md'
+    compileSdk 33
     defaultConfig {
         applicationId "com.google.mlkit.md"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -36,10 +37,6 @@ android {
     sourceSets.main {
         assets.srcDirs = ['assets']
     }
-}
-
-androidExtensions {
-    experimental = true
 }
 
 dependencies {

--- a/android/material-showcase/app/src/main/AndroidManifest.xml
+++ b/android/material-showcase/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.google.mlkit.md"
     android:installLocation="auto">
 
   <uses-feature android:name="android.hardware.camera"/>

--- a/android/material-showcase/build.gradle
+++ b/android/material-showcase/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.8.20'
     repositories {
         google()
         jcenter()
@@ -9,8 +9,8 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.20"
     }
 }
 

--- a/android/material-showcase/gradle/wrapper/gradle-wrapper.properties
+++ b/android/material-showcase/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/ios/quickstarts/vision/VisionExample/UIUtilities.swift
+++ b/ios/quickstarts/vision/VisionExample/UIUtilities.swift
@@ -451,7 +451,7 @@ public class UIUtilities {
   ///
   /// - Parameters:
   ///   - fromPoint: The starting point.
-  ///   - endPoint: The end point.
+  ///   - toPoint: The end point.
   /// - Returns: The distance.
   private static func distance(fromPoint: Vision3DPoint, toPoint: Vision3DPoint) -> CGFloat {
     let xDiff = fromPoint.x - toPoint.x


### PR DESCRIPTION
Upgrade Gradle, AGP, and sub out removed kotlin-android-extensions within. This was all required to get the project to build in both AS Giraffe 2022.3.1 Stable and AS Hedgehog 2023.1.1 Canary 13 on an M2 Macbook.

Opened #704 to capture this issue specifically, which is wholly fixed by this PR and will unblock folks trying to run these samples. Though it sounds like this also addresses part of #685, but that issue sounds like it may be asking for architectural changes as well.